### PR TITLE
Add Cognito configuration

### DIFF
--- a/cognito.tf
+++ b/cognito.tf
@@ -1,0 +1,11 @@
+resource "aws_cognito_user_group" "read_only_group" {
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+  name         = "read-only"
+  description  = "Read-only access group"
+}
+
+resource "aws_cognito_user_group" "admin_group" {
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+  name         = "admin"
+  description  = "Admin access group"
+}

--- a/docs/current.de.md
+++ b/docs/current.de.md
@@ -45,3 +45,30 @@ Kommentar beschriebene Werte annehmen kann
 | liedtext | String | komplett Text des Liedes als String für die Volltextsuche|
 | liturgischString | Enum(String) | Advent-Weihnachten/Fastenzeit/Ostern-Pfingsten/Jahreskreis|
 | thematischString | Enum(String) |Marienlieder/Lieder-für-die-Kinder/ Einzugslieder/|Frieden-Gabenbereitung/Brotbrechen/Kelchkommunion/Auszugslieder|
+
+## Unterscheidung der Gruppen bei JWT-Verarbeitung
+
+Die beiden Gruppen (read-only und admin) können bei der Verarbeitung des ausgegebenen JWTs wie folgt unterschieden werden:
+
+1. **JWT-Dekodierung**: Dekodieren Sie das JWT, um die darin enthaltenen Ansprüche (Claims) zu extrahieren. Dies kann mit einer JWT-Bibliothek in der verwendeten Programmiersprache erfolgen.
+
+2. **Überprüfung der Gruppenansprüche**: Überprüfen Sie die Ansprüche im JWT, um festzustellen, zu welcher Gruppe der Benutzer gehört. In den Ansprüchen sollte ein Attribut enthalten sein, das die Gruppenzugehörigkeit des Benutzers angibt (z. B. `cognito:groups`).
+
+3. **Unterscheidung der Gruppen**: Basierend auf dem Wert des Gruppenattributs können Sie den Benutzer als Mitglied der read-only oder admin Gruppe identifizieren und entsprechende Berechtigungen zuweisen.
+
+Beispiel in pseudocode:
+
+```
+jwt = decode_jwt(token)
+groups = jwt['cognito:groups']
+
+if 'admin' in groups:
+    # Benutzer ist ein Admin
+    grant_admin_permissions()
+elif 'read-only' in groups:
+    # Benutzer ist ein Read-Only-Benutzer
+    grant_read_only_permissions()
+else:
+    # Benutzer gehört keiner bekannten Gruppe an
+    deny_access()
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_cognito_user_pool" "user_pool" {
+  name = var.cognito_user_pool_name
+
+  password_policy {
+    minimum_length    = 8
+    require_lowercase = true
+    require_numbers   = true
+    require_symbols   = true
+    require_uppercase = true
+  }
+
+  mfa_configuration = "ON"
+
+  software_token_mfa_configuration {
+    enabled = true
+  }
+
+}
+
+resource "aws_cognito_user_pool_client" "user_pool_client" {
+  name         = var.cognito_user_pool_client_name
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+
+  explicit_auth_flows = [
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
+  ]
+}
+
+resource "aws_cognito_user_pool_domain" "user_pool_domain" {
+  domain      = var.cognito_user_pool_domain_name
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,11 @@
+output "cognito_user_pool_id" {
+  value = aws_cognito_user_pool.user_pool.id
+}
+
+output "cognito_user_pool_client_id" {
+  value = aws_cognito_user_pool_client.user_pool_client.id
+}
+
+output "cognito_user_pool_domain" {
+  value = aws_cognito_user_pool_domain.user_pool_domain.domain
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "cognito_user_pool_name" {
+  description = "The name of the Cognito user pool"
+  type        = string
+}
+
+variable "cognito_user_pool_client_name" {
+  description = "The name of the Cognito user pool client"
+  type        = string
+}
+
+variable "cognito_user_pool_domain_name" {
+  description = "The name of the Cognito user pool domain"
+  type        = string
+}


### PR DESCRIPTION
Fixes #6

Add Cognito configuration using Terraform module.

* Add `main.tf` with Cognito user pool, user pool client, and user pool domain configurations.
* Add `cognito.tf` with read-only and admin user group configurations.
* Add `outputs.tf` with outputs for Cognito user pool ID, user pool client ID, and user pool domain.
* Add `variables.tf` with variables for Cognito user pool name, user pool client name, and user pool domain name.
* Modify `docs/current.de.md` to include a section explaining how to distinguish between read-only and admin groups when processing the issued JWT.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cncde/songs-infrastructure/pull/7?shareId=acfbbfbf-1021-4706-ba9b-a6de1fa6d926).